### PR TITLE
Fix lark-cli --profile isolation and add pre-flight checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,5 @@ OPENBB_FMP_API_KEY=
 OPENBB_FRED_API_KEY=
 
 # Feishu Bot — Whitelisted User open_id
-# Get via: lark-cli auth login && lark-cli contact +me
+# Get via: lark-cli --profile finance-agent auth login && lark-cli --profile finance-agent contact +get-user
 ALLOWED_OPEN_ID=ou_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ Append new recommendations to `recommendations.csv` with `status=pending`. Use t
 
 ### Step 7 — Push & Archive
 
-Push the report summary to Feishu via `lark-cli im send`. Full report stays in `reports/`. Log end-of-run to `agent.log`. Release lock.
+Push the report summary to Feishu via `lark-cli --profile finance-agent im send`. Full report stays in `reports/`. Log end-of-run to `agent.log`. Release lock.
 
 ## Path B: Feishu On-Demand Interaction
 
@@ -151,12 +151,12 @@ When `feishu-listener.sh` receives a message from the whitelisted `ALLOWED_OPEN_
 ### How to Send Feishu Messages
 
 ```bash
-# Send to the whitelisted user
-lark-cli im send --user "$SENDER_ID" --msg "message text"
+# Send to the whitelisted user (always use project profile)
+lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "message text"
 
 # For long messages, write to temp file then send
 echo "$LONG_MSG" > /tmp/feishu_response.txt
-lark-cli im send --user "$SENDER_ID" --msg "$(cat /tmp/feishu_response.txt)"
+lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "$(cat /tmp/feishu_response.txt)"
 ```
 
 ## OpenBB Usage Pattern

--- a/docs/prd-v0.0.2.md
+++ b/docs/prd-v0.0.2.md
@@ -315,7 +315,8 @@ flock -n 200 || {
 }
 
 log_event() {
-  echo "{\"ts\":\"$(date -Iseconds)\",\"event\":\"feishu_query\",\"sender\":\"$SENDER_ID\",\"msg\":\"$(echo "$1" | jq -Rs .)\"}" >> agent.log
+  jq -n --arg ts "$(date -Iseconds)" --arg event "feishu_query" --arg sender "$SENDER_ID" --arg mid "$MSG_ID" --arg msg "$1" \
+    '{ts: $ts, event: $event, sender: $sender, message_id: $mid, msg: $msg}' >> agent.log
 }
 
 log_event "$MSG_TEXT"
@@ -331,7 +332,8 @@ if echo "$INTENT" | grep -qE "^报告$|最新报告"; then
   # 报告查询：读取最新报告直接推送，不经过 Claude Code
   LATEST=$(find reports/ -maxdepth 1 -name 'analysis-*.md' 2>/dev/null | sort -r | head -1)
   if [[ -n "$LATEST" ]]; then
-    SUMMARY=$(head -80 "$LATEST")
+    # 飞书单条消息约 3000 字符限制，预留 200 字符给前后缀，取报告前 2800 字符作为摘要
+    SUMMARY=$(head -c 2800 "$LATEST")
     lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "$(printf '📊 最新分析报告\n\n%s\n\n──\n完整报告: %s' "$SUMMARY" "$LATEST")"
   else
     lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "暂无分析报告，请先触发一次定时分析或使用「分析」指令。"
@@ -350,6 +352,11 @@ elif echo "$INTENT" | grep -qE "分析|持仓|诊断|portfolio"; then
 elif echo "$INTENT" | grep -qE "^[a-z]{1,5}$|查.*价格|看.*[a-z]{1,5}|快查"; then
   # 个股快查：从消息中提取 ticker
   TICKER=$(echo "$MSG_TEXT" | grep -oE '[A-Za-z]{1,5}' | head -1)
+  if [[ -z "$TICKER" ]]; then
+    lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "未识别到股票代码，请使用如「查 AAPL」或「TSLA」的格式。"
+    flock -u 200
+    exit 0
+  fi
   claude "用户通过飞书查询 $TICKER 的当前状态。请执行快速诊断（仅该标的）：
   1. 拉取价格、技术指标（RSI/MACD/MA）、基本面
   2. 输出：当前价、涨跌幅、技术面判断、是否处于目标区间、一句话操作建议

--- a/docs/prd-v0.0.2.md
+++ b/docs/prd-v0.0.2.md
@@ -231,12 +231,12 @@ Trigger → Load → Collect → Think & Verify → Generate → Write Recs → 
 | 订阅方式 | WebSocket 长连接 | 无需公网 URL，本地 Mac mini 直连 |
 
 ```bash
-# 使用 lark-cli 初始化配置（在 Mac mini 上执行一次）
-lark-cli config init
-lark-cli auth login        # 按提示完成 OAuth 登录
+# 使用 lark-cli 以独立 profile 初始化配置（在 Mac mini 上执行一次）
+# --profile finance-agent 确保与用户本机其他 lark-cli 配置隔离
+lark-cli --profile finance-agent auth login
 
 # 配置完成后验证
-lark-cli im send --user <your_open_id> --msg "Agent 上线"
+lark-cli --profile finance-agent im send --user <your_open_id> --msg "Agent 上线"
 ```
 
 ### 6.4 消息监听：`scripts/feishu-listener.sh`
@@ -251,6 +251,19 @@ set -euo pipefail
 PROJECT_DIR="/Users/yourname/finance-agent"
 cd "$PROJECT_DIR"
 
+# ── 前置检查 ──
+# 1. 检查 lark-cli 是否安装
+if ! command -v lark-cli &> /dev/null; then
+  echo "[FATAL] lark-cli 未安装，请先安装 lark-cli 后重新运行。" >&2
+  exit 1
+fi
+
+# 2. 检查 finance-agent profile 是否已登录
+if ! lark-cli --profile finance-agent contact +get-user &> /dev/null; then
+  echo "[FATAL] finance-agent profile 未登录，请先执行: lark-cli --profile finance-agent auth login" >&2
+  exit 1
+fi
+
 # 载入环境变量
 set -a
 source .env 2>/dev/null || true
@@ -260,7 +273,7 @@ source venv/bin/activate
 
 # lark-event 通过 WebSocket 长连接监听消息事件
 # 输出为 NDJSON，每行一条事件，通过管道交给 intent_router 处理
-lark-event \
+lark-event --profile finance-agent \
   --event-type im.message.receive_v1 \
   --compact \
   --output-ndjson \
@@ -297,7 +310,7 @@ cd "$PROJECT_DIR"
 # 互斥锁：避免与定时分析同时运行
 exec 200>"$LOCK_FILE"
 flock -n 200 || {
-  lark-cli im send --user "$SENDER_ID" --msg "Agent 正在执行分析任务，请稍后再试。"
+  lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "Agent 正在执行分析任务，请稍后再试。"
   exit 0
 }
 
@@ -309,15 +322,29 @@ log_event "$MSG_TEXT"
 
 INTENT=$(echo "$MSG_TEXT" | tr '[:upper:]' '[:lower:]')
 
+# 对消息文本做 shell 转义，防止 $MSG_TEXT 包含的特殊字符被 bash 解释
+MSG_TEXT_SAFE=$(printf '%s' "$MSG_TEXT" | sed 's/[\\"$`]/\\&/g')
+
 # ── 意图识别与路由 ──
 
-if echo "$INTENT" | grep -qE "分析|持仓|诊断|报告|portfolio"; then
+if echo "$INTENT" | grep -qE "^报告$|最新报告"; then
+  # 报告查询：读取最新报告直接推送，不经过 Claude Code
+  LATEST=$(find reports/ -maxdepth 1 -name 'analysis-*.md' 2>/dev/null | sort -r | head -1)
+  if [[ -n "$LATEST" ]]; then
+    SUMMARY=$(head -80 "$LATEST")
+    lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "$(printf '📊 最新分析报告\n\n%s\n\n──\n完整报告: %s' "$SUMMARY" "$LATEST")"
+  else
+    lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "暂无分析报告，请先触发一次定时分析或使用「分析」指令。"
+  fi
+
+elif echo "$INTENT" | grep -qE "分析|持仓|诊断|portfolio"; then
   # 完整持仓分析
   claude "用户通过飞书发起了一次持仓分析请求。请按照 CLAUDE.md 中的完整工作流执行分析，但注意：
   1. 报告需要精简（控制在飞书单条消息长度内，约 3000 字符），核心输出「操作建议表」+「历史准确率」
   2. 不要归档到 reports/（这是按需查询，非定时分析）
   3. 不要写入 recommendations.csv（非正式建议）
   4. 分析结束后，将结果通过飞书发送给用户 open_id=$SENDER_ID
+  4.1 飞书发送消息请使用: lark-cli --profile finance-agent im send --user \"$SENDER_ID\" --msg \"...\"
   触发时间: $(date '+%Y-%m-%d %H:%M') | 触发方式: 飞书按需"
 
 elif echo "$INTENT" | grep -qE "^[a-z]{1,5}$|查.*价格|看.*[a-z]{1,5}|快查"; then
@@ -327,7 +354,8 @@ elif echo "$INTENT" | grep -qE "^[a-z]{1,5}$|查.*价格|看.*[a-z]{1,5}|快查"
   1. 拉取价格、技术指标（RSI/MACD/MA）、基本面
   2. 输出：当前价、涨跌幅、技术面判断、是否处于目标区间、一句话操作建议
   3. 结果控制在 1500 字符内
-  4. 通过飞书发送给用户 open_id=$SENDER_ID"
+  4. 通过飞书发送给用户 open_id=$SENDER_ID
+  4.1 飞书发送消息请使用: lark-cli --profile finance-agent im send --user \"$SENDER_ID\" --msg \"...\""
 
 elif echo "$INTENT" | grep -qE "准确率|回溯|建议.*记录|历史|verify"; then
   # 建议回溯查询
@@ -335,10 +363,11 @@ elif echo "$INTENT" | grep -qE "准确率|回溯|建议.*记录|历史|verify"; 
   1. 最近 30 天准确率统计（按 action 类型 + 按标的分）
   2. 连续失误标记
   3. 结果控制在 2000 字符内
-  4. 通过飞书发送给用户 open_id=$SENDER_ID"
+  4. 通过飞书发送给用户 open_id=$SENDER_ID
+  4.1 飞书发送消息请使用: lark-cli --profile finance-agent im send --user \"$SENDER_ID\" --msg \"...\""
 
 elif echo "$INTENT" | grep -qE "help|帮助|命令|怎么用"; then
-  lark-cli im send --user "$SENDER_ID" --msg "$(cat <<'HELP'
+  lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "$(cat <<'HELP'
 📋 Finance Agent 可用指令：
 
 • 「分析」/「持仓诊断」 — 完整持仓分析与操作建议
@@ -351,8 +380,8 @@ HELP
 
 else
   # 通用问答：交由 Claude Code 自由理解
-  claude "用户通过飞书发送了以下消息: \"$MSG_TEXT\"
-这是来自投资分析 agent 用户的按需查询。请根据 CLAUDE.md 上下文和当前数据文件（portfolio.csv, recommendations.csv），用投资分析的视角回答用户的问题。回答控制在 2000 字符内。通过飞书发送给用户 open_id=$SENDER_ID。"
+  claude "用户通过飞书发送了以下消息: ${MSG_TEXT_SAFE}
+这是来自投资分析 agent 用户的按需查询。请根据 CLAUDE.md 上下文和当前数据文件（portfolio.csv, recommendations.csv），用投资分析的视角回答用户的问题。回答控制在 2000 字符内。通过飞书发送给用户 open_id=$SENDER_ID。飞书发送消息请使用: lark-cli --profile finance-agent im send --user \"$SENDER_ID\" --msg \"...\""
 fi
 
 flock -u 200
@@ -590,8 +619,8 @@ finance-agent/
 - [ ] 在飞书开放平台创建企业自建应用
 - [ ] 配置 `im:message:send_as_bot` / `im:message:read` / `im:message:event` 权限
 - [ ] 订阅 `im.message.receive_v1` 事件（WebSocket 方式）
-- [ ] 获取并记录自己的 `open_id`（通过 `lark-cli auth login`）
-- [ ] 验证：`lark-cli im send --user <open_id> --msg "hello"` 确认通路
+- [ ] 获取并记录自己的 `open_id`（通过 `lark-cli --profile finance-agent auth login`）
+- [ ] 验证：`lark-cli --profile finance-agent im send --user <open_id> --msg "hello"` 确认通路
 
 ### Phase 3: 数据文件
 - [ ] 创建 `portfolio.csv`（按 Schema，填入你的实际持仓）

--- a/run-analysis.sh
+++ b/run-analysis.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# run-analysis.sh — 定时分析包装脚本
+# 由 launchd 在工作日 9:00 / 13:00 触发
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$PROJECT_DIR"
+
+# ── 前置检查 ──
+# 1. 检查 lark-cli 是否安装
+if ! command -v lark-cli &> /dev/null; then
+  echo "[FATAL] lark-cli 未安装，请先安装 lark-cli 后重新运行。" >&2
+  exit 1
+fi
+
+# 2. 检查 finance-agent profile 是否已登录
+if ! lark-cli --profile finance-agent contact +get-user &> /dev/null; then
+  echo "[FATAL] finance-agent profile 未登录，请先执行: lark-cli --profile finance-agent auth login" >&2
+  exit 1
+fi
+
+# ── Step 1: Acquire Lock ──
+exec 200>".analysis.lock"
+flock 200
+
+# 载入环境变量
+set -a
+# shellcheck disable=SC1091
+source .env 2>/dev/null || true
+set +a
+
+# shellcheck disable=SC1091
+source venv/bin/activate
+
+echo "{\"ts\":\"$(date -Iseconds)\",\"event\":\"start\",\"trigger\":\"launchd\"}" >> agent.log
+
+# ── Step 2-6: 由 Claude Code 驱动完整分析工作流 ──
+# Claude Code 读取 CLAUDE.md 并执行 Steps 2-6（加载状态、收集数据、验证历史、分析、生成报告、写入建议）
+# --profile finance-agent 确保飞书推送使用正确的配置
+claude "请按照 CLAUDE.md 中的完整 7-Step 定时分析工作流执行本次分析。
+
+当前时间: $(date '+%Y-%m-%d %H:%M:%S')
+触发方式: launchd 定时触发
+
+注意事项:
+- Step 7 飞书推送请使用: lark-cli --profile finance-agent im send --user \"$ALLOWED_OPEN_ID\" --msg \"...\"
+- 完整报告归档到 reports/ 目录
+- 日志写入 agent.log
+- 结束后释放文件锁"
+
+# ── Step 7: Push & Archive ──
+# 报告推送由 Claude Code 在会话中完成（通过 lark-cli --profile finance-agent im send）
+# 此处仅为兜底日志
+
+echo "{\"ts\":\"$(date -Iseconds)\",\"event\":\"end\",\"trigger\":\"launchd\"}" >> agent.log
+
+# 释放文件锁
+flock -u 200

--- a/run-analysis.sh
+++ b/run-analysis.sh
@@ -29,6 +29,13 @@ set -a
 source .env 2>/dev/null || true
 set +a
 
+# 检查必需的环境变量
+if [[ -z "${ALLOWED_OPEN_ID:-}" ]]; then
+  echo "[FATAL] ALLOWED_OPEN_ID 环境变量未设置，请在 .env 中配置。" >&2
+  flock -u 200
+  exit 1
+fi
+
 # shellcheck disable=SC1091
 source venv/bin/activate
 

--- a/scripts/feishu-listener.sh
+++ b/scripts/feishu-listener.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# feishu-listener.sh — 飞书消息监听守护进程
+# 由 launchd 守护全天候运行，监听飞书 IM 消息事件
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_DIR"
+
+# ── 前置检查 ──
+# 1. 检查 lark-cli 是否安装
+if ! command -v lark-cli &> /dev/null; then
+  echo "[FATAL] lark-cli 未安装，请先安装 lark-cli 后重新运行。" >&2
+  exit 1
+fi
+
+# 2. 检查 finance-agent profile 是否已登录
+if ! lark-cli --profile finance-agent contact +get-user &> /dev/null; then
+  echo "[FATAL] finance-agent profile 未登录，请先执行: lark-cli --profile finance-agent auth login" >&2
+  exit 1
+fi
+
+# 载入环境变量
+set -a
+# shellcheck disable=SC1091
+source .env 2>/dev/null || true
+set +a
+
+# 检查必需的环境变量
+if [[ -z "${ALLOWED_OPEN_ID:-}" ]]; then
+  echo "[FATAL] ALLOWED_OPEN_ID 环境变量未设置，请在 .env 中配置。" >&2
+  exit 1
+fi
+
+# 激活 Python 虚拟环境
+# shellcheck disable=SC1091
+source venv/bin/activate
+
+echo "[$(date -Iseconds)] feishu-listener started, profile=finance-agent" >> agent.log
+
+# lark-event 通过 WebSocket 长连接监听消息事件
+# 输出为 NDJSON，每行一条事件，通过管道交给 intent_router 处理
+lark-event --profile finance-agent \
+  --event-type im.message.receive_v1 \
+  --compact \
+  --output-ndjson \
+  | while IFS= read -r event_line; do
+      # 跳过空行
+      [[ -z "$event_line" ]] && continue
+
+      # 提取消息内容与发送者信息
+      MSG_TEXT=$(echo "$event_line" | jq -r '.message.content // empty')
+      SENDER_ID=$(echo "$event_line" | jq -r '.sender.open_id // empty')
+      MSG_ID=$(echo "$event_line" | jq -r '.message.message_id // empty')
+
+      # 跳过无法解析的消息
+      if [[ -z "$MSG_TEXT" || -z "$SENDER_ID" ]]; then
+        echo "[$(date -Iseconds)] skipped unparseable event" >> agent.log
+        continue
+      fi
+
+      # 身份校验：仅响应白名单用户
+      if [[ "$SENDER_ID" != "$ALLOWED_OPEN_ID" ]]; then
+        echo "[$(date -Iseconds)] rejected unknown sender: $SENDER_ID" >> agent.log
+        continue
+      fi
+
+      # 解析意图并路由到 Claude Code 会话
+      bash scripts/intent_router.sh "$MSG_TEXT" "$SENDER_ID" "$MSG_ID" &
+    done

--- a/scripts/intent_router.sh
+++ b/scripts/intent_router.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# intent_router.sh — 解析用户意图并路由到对应的 Claude Code 会话
+set -euo pipefail
+
+MSG_TEXT="$1"
+SENDER_ID="$2"
+MSG_ID="$3"
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LOCK_FILE="$PROJECT_DIR/.analysis.lock"
+
+cd "$PROJECT_DIR"
+
+# 互斥锁：避免与定时分析同时运行
+exec 200>"$LOCK_FILE"
+if ! flock -n 200; then
+  lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "Agent 正在执行分析任务，请稍后再试。"
+  exit 0
+fi
+
+log_event() {
+  echo "{\"ts\":\"$(date -Iseconds)\",\"event\":\"feishu_query\",\"sender\":\"$SENDER_ID\",\"message_id\":\"$MSG_ID\",\"msg\":\"$(echo "$1" | jq -Rs .)\"}" >> agent.log
+}
+
+log_event "$MSG_TEXT"
+
+INTENT=$(echo "$MSG_TEXT" | tr '[:upper:]' '[:lower:]')
+
+# 对消息文本做 shell 转义，防止 $MSG_TEXT 包含的特殊字符被 bash 解释
+MSG_TEXT_SAFE=$(printf '%s' "$MSG_TEXT" | sed 's/[\\"$`]/\\&/g')
+
+# ── 意图识别与路由 ──
+
+if echo "$INTENT" | grep -qE "^报告$|最新报告"; then
+  # 报告查询：读取最新报告直接推送，不经过 Claude Code
+  LATEST=$(find reports/ -maxdepth 1 -name 'analysis-*.md' 2>/dev/null | sort -r | head -1)
+  if [[ -n "$LATEST" ]]; then
+    # 飞书单条消息约 3000 字符限制，取报告前 80 行作为摘要
+    SUMMARY=$(head -80 "$LATEST")
+    lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "$(printf '📊 最新分析报告\n\n%s\n\n──\n完整报告: %s' "$SUMMARY" "$LATEST")"
+  else
+    lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "暂无分析报告，请先触发一次定时分析或使用「分析」指令。"
+  fi
+
+elif echo "$INTENT" | grep -qE "分析|持仓|诊断|portfolio"; then
+  # 完整持仓分析
+  claude "用户通过飞书发起了一次持仓分析请求。请按照 CLAUDE.md 中的完整工作流执行分析，但注意：
+  1. 报告需要精简（控制在飞书单条消息长度内，约 3000 字符），核心输出「操作建议表」+「历史准确率」
+  2. 不要归档到 reports/（这是按需查询，非定时分析）
+  3. 不要写入 recommendations.csv（非正式建议）
+  4. 分析结束后，将结果通过飞书发送给用户 open_id=$SENDER_ID
+  4.1 飞书发送消息请使用: lark-cli --profile finance-agent im send --user \"$SENDER_ID\" --msg \"...\"
+  触发时间: $(date '+%Y-%m-%d %H:%M') | 触发方式: 飞书按需"
+
+elif echo "$INTENT" | grep -qE "^[a-z]{1,5}$|查.*价格|看.*[a-z]{1,5}|快查"; then
+  # 个股快查：从消息中提取 ticker
+  TICKER=$(echo "$MSG_TEXT" | grep -oE '[A-Za-z]{1,5}' | head -1)
+  claude "用户通过飞书查询 $TICKER 的当前状态。请执行快速诊断（仅该标的）：
+  1. 拉取价格、技术指标（RSI/MACD/MA）、基本面
+  2. 输出：当前价、涨跌幅、技术面判断、是否处于目标区间、一句话操作建议
+  3. 结果控制在 1500 字符内
+  4. 通过飞书发送给用户 open_id=$SENDER_ID
+  4.1 飞书发送消息请使用: lark-cli --profile finance-agent im send --user \"$SENDER_ID\" --msg \"...\""
+
+elif echo "$INTENT" | grep -qE "准确率|回溯|建议.*记录|历史|verify"; then
+  # 建议回溯查询
+  claude "用户通过飞书查询历史建议准确率。请读取 recommendations.csv，输出：
+  1. 最近 30 天准确率统计（按 action 类型 + 按标的分）
+  2. 连续失误标记
+  3. 结果控制在 2000 字符内
+  4. 通过飞书发送给用户 open_id=$SENDER_ID
+  4.1 飞书发送消息请使用: lark-cli --profile finance-agent im send --user \"$SENDER_ID\" --msg \"...\""
+
+elif echo "$INTENT" | grep -qE "help|帮助|命令|怎么用"; then
+  lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "$(cat <<'HELP'
+📋 Finance Agent 可用指令：
+
+• 「分析」/「持仓诊断」 — 完整持仓分析与操作建议
+• 「AAPL」/「查 TSLA」 — 个股快速诊断（价格+技术指标+建议）
+• 「准确率」/「历史回溯」 — 查看历史建议准确率统计
+• 「报告」 — 推送最近一次定时分析报告
+• 「异动提醒开/关」 — 开启/关闭价格异动提醒
+HELP
+)"
+
+else
+  # 通用问答：交由 Claude Code 自由理解
+  claude "用户通过飞书发送了以下消息: ${MSG_TEXT_SAFE}
+这是来自投资分析 agent 用户的按需查询。请根据 CLAUDE.md 上下文和当前数据文件（portfolio.csv, recommendations.csv），用投资分析的视角回答用户的问题。回答控制在 2000 字符内。通过飞书发送给用户 open_id=$SENDER_ID。飞书发送消息请使用: lark-cli --profile finance-agent im send --user \"$SENDER_ID\" --msg \"...\""
+fi
+
+flock -u 200

--- a/scripts/intent_router.sh
+++ b/scripts/intent_router.sh
@@ -19,7 +19,8 @@ if ! flock -n 200; then
 fi
 
 log_event() {
-  echo "{\"ts\":\"$(date -Iseconds)\",\"event\":\"feishu_query\",\"sender\":\"$SENDER_ID\",\"message_id\":\"$MSG_ID\",\"msg\":\"$(echo "$1" | jq -Rs .)\"}" >> agent.log
+  jq -n --arg ts "$(date -Iseconds)" --arg event "feishu_query" --arg sender "$SENDER_ID" --arg mid "$MSG_ID" --arg msg "$1" \
+    '{ts: $ts, event: $event, sender: $sender, message_id: $mid, msg: $msg}' >> agent.log
 }
 
 log_event "$MSG_TEXT"
@@ -35,8 +36,8 @@ if echo "$INTENT" | grep -qE "^报告$|最新报告"; then
   # 报告查询：读取最新报告直接推送，不经过 Claude Code
   LATEST=$(find reports/ -maxdepth 1 -name 'analysis-*.md' 2>/dev/null | sort -r | head -1)
   if [[ -n "$LATEST" ]]; then
-    # 飞书单条消息约 3000 字符限制，取报告前 80 行作为摘要
-    SUMMARY=$(head -80 "$LATEST")
+    # 飞书单条消息约 3000 字符限制，预留 200 字符给前后缀，取报告前 2800 字符作为摘要
+    SUMMARY=$(head -c 2800 "$LATEST")
     lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "$(printf '📊 最新分析报告\n\n%s\n\n──\n完整报告: %s' "$SUMMARY" "$LATEST")"
   else
     lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "暂无分析报告，请先触发一次定时分析或使用「分析」指令。"
@@ -55,6 +56,11 @@ elif echo "$INTENT" | grep -qE "分析|持仓|诊断|portfolio"; then
 elif echo "$INTENT" | grep -qE "^[a-z]{1,5}$|查.*价格|看.*[a-z]{1,5}|快查"; then
   # 个股快查：从消息中提取 ticker
   TICKER=$(echo "$MSG_TEXT" | grep -oE '[A-Za-z]{1,5}' | head -1)
+  if [[ -z "$TICKER" ]]; then
+    lark-cli --profile finance-agent im send --user "$SENDER_ID" --msg "未识别到股票代码，请使用如「查 AAPL」或「TSLA」的格式。"
+    flock -u 200
+    exit 0
+  fi
   claude "用户通过飞书查询 $TICKER 的当前状态。请执行快速诊断（仅该标的）：
   1. 拉取价格、技术指标（RSI/MACD/MA）、基本面
   2. 输出：当前价、涨跌幅、技术面判断、是否处于目标区间、一句话操作建议


### PR DESCRIPTION
Closes #18

## Summary
- Add `--profile finance-agent` to all `lark-cli`/`lark-event` calls across scripts and docs to prevent config conflicts with user's other lark-cli profiles
- Add pre-flight checks in `feishu-listener.sh` and `run-analysis.sh`: lark-cli installation check + finance-agent profile login check
- Create `scripts/feishu-listener.sh`, `scripts/intent_router.sh`, and `run-analysis.sh` with proper profile isolation
- Fix intent routing: "报告" intent now reads latest report from `reports/` and pushes directly (no Claude Code session required)
- Sanitize `$MSG_TEXT` before passing to `claude` CLI to prevent command injection
- Update PRD Phase 2 checklist and `.env.example` with correct `--profile finance-agent` commands

## Test plan
- [x] Shellcheck passes on all 3 scripts (zero warnings)
- [x] Simulated lark-cli not installed → `[FATAL]` + exit 1
- [x] Simulated profile exists but not logged in → `[FATAL]` + exit 1
- [x] Verified profile exists and logged in → passes both checks
- [x] Verified all lark-cli/lark-event calls include `--profile` (0 uncovered)
- [x] Verified command injection fix in place (`MSG_TEXT_SAFE` sanitization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)