### PR TITLE
Add launchd scheduling configs for automated analysis and Feishu listener

### DIFF
--- a/launchd/com.finance-agent.analysis.plist
+++ b/launchd/com.finance-agent.analysis.plist
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.finance-agent.analysis</string>
+
+    <key>Comment</key>
+    <string>Finance Agent — Path A: Scheduled portfolio analysis (weekdays 9:00 &amp; 13:00)</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/opt/homebrew/bin/python3</string>
+      <string>/Users/zeru/.coding-agent/worktrees/finance-agent/issue-10-launchd/scripts/run-analysis.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/zeru/.coding-agent/worktrees/finance-agent/issue-10-launchd</string>
+
+    <key>StartCalendarInterval</key>
+    <array>
+      <dict>
+        <key>Weekday</key>
+        <integer>1</integer>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+      </dict>
+      <dict>
+        <key>Weekday</key>
+        <integer>1</integer>
+        <key>Hour</key>
+        <integer>13</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+      </dict>
+      <dict>
+        <key>Weekday</key>
+        <integer>2</integer>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+      </dict>
+      <dict>
+        <key>Weekday</key>
+        <integer>2</integer>
+        <key>Hour</key>
+        <integer>13</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+      </dict>
+      <dict>
+        <key>Weekday</key>
+        <integer>3</integer>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+      </dict>
+      <dict>
+        <key>Weekday</key>
+        <integer>3</integer>
+        <key>Hour</key>
+        <integer>13</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+      </dict>
+      <dict>
+        <key>Weekday</key>
+        <integer>4</integer>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+      </dict>
+      <dict>
+        <key>Weekday</key>
+        <integer>4</integer>
+        <key>Hour</key>
+        <integer>13</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+      </dict>
+      <dict>
+        <key>Weekday</key>
+        <integer>5</integer>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+      </dict>
+      <dict>
+        <key>Weekday</key>
+        <integer>5</integer>
+        <key>Hour</key>
+        <integer>13</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+      </dict>
+    </array>
+
+    <key>RunAtLoad</key>
+    <false/>
+    <key>KeepAlive</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/zeru/.coding-agent/worktrees/finance-agent/issue-10-launchd/logs/launchd-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/zeru/.coding-agent/worktrees/finance-agent/issue-10-launchd/logs/launchd-stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>HOME</key>
+      <string>/Users/zeru</string>
+      <key>ALLOWED_OPEN_ID</key>
+      <string>ou_c51af1689cf9f949f03d7ca822029c9e</string>
+      <key>PATH</key>
+      <string>/opt/homebrew/bin:/Users/zeru/.bun/bin:/Users/zeru/.deskclaw/node/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+  </dict>
+</plist>

--- a/launchd/com.finance-agent.feishu.plist
+++ b/launchd/com.finance-agent.feishu.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.finance-agent.feishu</string>
+
+    <key>Comment</key>
+    <string>Finance Agent — Path B: Feishu message listener daemon (7×24 WebSocket)</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/opt/homebrew/bin/python3</string>
+      <string>/Users/zeru/.coding-agent/worktrees/finance-agent/issue-10-launchd/scripts/feishu-listener.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/zeru/.coding-agent/worktrees/finance-agent/issue-10-launchd</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/zeru/.coding-agent/worktrees/finance-agent/issue-10-launchd/logs/feishu-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/zeru/.coding-agent/worktrees/finance-agent/issue-10-launchd/logs/feishu-stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>HOME</key>
+      <string>/Users/zeru</string>
+      <key>ALLOWED_OPEN_ID</key>
+      <string>ou_c51af1689cf9f949f03d7ca822029c9e</string>
+      <key>PATH</key>
+      <string>/opt/homebrew/bin:/Users/zeru/.bun/bin:/Users/zeru/.deskclaw/node/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+  </dict>
+</plist>


### PR DESCRIPTION
## Summary
- Add `launchd/com.finance-agent.analysis.plist` — weekday 9:00 & 13:00 scheduled portfolio analysis (Path A)
- Add `launchd/com.finance-agent.feishu.plist` — 7×24 Feishu message listener daemon (Path B)

## Details
**analysis.plist**
- `StartCalendarInterval`: Mon-Fri, 10 calendar entries (9:00 + 13:00 each weekday)
- `RunAtLoad=false`, `KeepAlive=false` — pure time-triggered, no persistent process
- Calls `python3 scripts/run-analysis.py` from project root

**feishu.plist**
- `RunAtLoad=true`, `KeepAlive=true` — auto-start on boot, auto-restart on crash
- `ThrottleInterval=10` — 10s cooldown between restarts
- Calls `python3 scripts/feishu-listener.py` from project root

Both include `EnvironmentVariables`: `HOME`, `ALLOWED_OPEN_ID`, `PATH` (with claude/lark-cli/python3 binary locations).

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)